### PR TITLE
Rename parameters of render_nav_item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Release date: --
 
 - Add ``safe_columns`` and ``urlize_columns`` parameters to ``render_table`` macro
   to support rendering table column as HTML/URL (`#204 <https://github.com/helloflask/bootstrap-flask/pull/204>`__).
+- Remame the ``badge`` parameter of ``render_nav_item`` macro to ``_badge``.
+- Remame the ``use_li`` parameter of ``render_nav_item`` macro to ``_use_li``.
 
 
 2.0.2

--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -25,12 +25,12 @@ Example
 API
 ~~~~
 
-.. py:function:: render_nav_item(endpoint, text, badge='', use_li=False, **kwargs)
+.. py:function:: render_nav_item(endpoint, text, _badge='', _use_li=False, **kwargs)
 
     :param endpoint: The endpoint used to generate URL.
     :param text: The text that will displayed on the item.
-    :param badge: Badge text.
-    :param use_li: Default to generate ``<a></a>``, if set to ``True``, it will generate ``<li><a></a></li>``.
+    :param _badge: Badge text.
+    :param _use_li: Default to generate ``<a></a>``, if set to ``True``, it will generate ``<li><a></a></li>``.
     :param kwargs: Additional keyword arguments pass to ``url_for()``.
 
 

--- a/examples/bootstrap4/templates/base.html
+++ b/examples/bootstrap4/templates/base.html
@@ -29,14 +29,14 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
-                {{ render_nav_item('index', 'Home', use_li=True) }}
-                {{ render_nav_item('test_form', 'Form', use_li=True) }}
-                {{ render_nav_item('test_nav', 'Nav', use_li=True) }}
-                {{ render_nav_item('test_pagination', 'Pagination', use_li=True) }}
-                {{ render_nav_item('test_flash', 'Flash Messages', use_li=True) }}
-                {{ render_nav_item('test_table', 'Table', use_li=True) }}
-                {{ render_nav_item('test_icon', 'Icon', use_li=True) }}
-                {{ render_nav_item('test_icons', 'Icons', use_li=True) }}
+                {{ render_nav_item('index', 'Home') }}
+                {{ render_nav_item('test_form', 'Form') }}
+                {{ render_nav_item('test_nav', 'Nav') }}
+                {{ render_nav_item('test_pagination', 'Pagination') }}
+                {{ render_nav_item('test_flash', 'Flash Messages') }}
+                {{ render_nav_item('test_table', 'Table') }}
+                {{ render_nav_item('test_icon', 'Icon') }}
+                {{ render_nav_item('test_icons', 'Icons') }}
                 <li class="nav-item"><a class="nav-link" href="https://bootstrap-flask.readthedocs.io/" target="_blank">Documentation</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://getbootstrap.com/docs/4.6/getting-started/introduction/" target="_blank">Bootstrap Documentation</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://github.com/greyli/bootstrap-flask" target="_blank">GitHub</a></li>

--- a/examples/bootstrap5/templates/base.html
+++ b/examples/bootstrap5/templates/base.html
@@ -30,14 +30,14 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
-                {{ render_nav_item('index', 'Home', use_li=True) }}
-                {{ render_nav_item('test_form', 'Form', use_li=True) }}
-                {{ render_nav_item('test_nav', 'Nav', use_li=True) }}
-                {{ render_nav_item('test_pagination', 'Pagination', use_li=True) }}
-                {{ render_nav_item('test_flash', 'Flash Messages', use_li=True) }}
-                {{ render_nav_item('test_table', 'Table', use_li=True) }}
-                {{ render_nav_item('test_icon', 'Icon', use_li=True) }}
-                {{ render_nav_item('test_icons', 'Icons', use_li=True) }}
+                {{ render_nav_item('index', 'Home') }}
+                {{ render_nav_item('test_form', 'Form') }}
+                {{ render_nav_item('test_nav', 'Nav') }}
+                {{ render_nav_item('test_pagination', 'Pagination') }}
+                {{ render_nav_item('test_flash', 'Flash Messages') }}
+                {{ render_nav_item('test_table', 'Table') }}
+                {{ render_nav_item('test_icon', 'Icon') }}
+                {{ render_nav_item('test_icons', 'Icons') }}
                 <li class="nav-item"><a class="nav-link" href="https://bootstrap-flask.readthedocs.io/" target="_blank">Documentation</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://getbootstrap.com/docs/5.1/getting-started/introduction/" target="_blank">Bootstrap Documentation</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://github.com/greyli/bootstrap-flask" target="_blank">GitHub</a></li>

--- a/flask_bootstrap/templates/base/nav.html
+++ b/flask_bootstrap/templates/base/nav.html
@@ -1,11 +1,11 @@
-{% macro render_nav_item(endpoint, text, badge='', use_li=False) %}
+{% macro render_nav_item(endpoint, text, _badge='', _use_li=False) %}
     {% set active = True if request.endpoint and request.endpoint == endpoint else False %}
-    {% if use_li %}<li class="nav-item">{% endif %}
-    <a class="{% if not use_li %}nav-item {% endif %}nav-link{% if active %} active" aria-current="page{% endif %}"
+    {% if _use_li %}<li class="nav-item">{% endif %}
+    <a class="{% if not _use_li %}nav-item {% endif %}nav-link{% if active %} active" aria-current="page{% endif %}"
        href="{{ url_for(endpoint, **kwargs) }}">
-        {{ text }} {% if badge %}<span class="badge badge-light">{{ badge }}</span>{% endif %}
+        {{ text }} {% if _badge %}<span class="badge badge-light">{{ _badge }}</span>{% endif %}
     </a>
-    {% if use_li %}</li>{% endif %}
+    {% if _use_li %}</li>{% endif %}
 {% endmacro %}
 
 


### PR DESCRIPTION
Rename the following parameters of the `render_nav_item` macro to prevent shadowing the user's URL variables.

- badge -> _badge
- use_li -> _use_li

fixes: #215

I didn't find the way to emit a deprecate warning in a macro. So this change will release with the 2.1 version directly.