### PR TITLE
Bump requirement from 2.0.2 to 2.1.0 to support urlize_columns

### DIFF
--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile examples.in
 #
-bootstrap-flask==2.0.2
+bootstrap-flask==2.1.0
     # via -r examples.in
 click==8.0.3
     # via flask


### PR DESCRIPTION
Fixes #246 as 2.1.0 introduced support for `urlize_columns`-keyword to render_table MACRO.