### PR TITLE
Add support for strict Content Security Policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 Release date: -
 
+- Add support for strict Content Security Policy (CSP) (`#252 <https://github.com/helloflask/bootstrap-flask/pull/252>`__)
+
 
 2.1.0
 -----

--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -59,9 +59,13 @@ Call it in your base template, for example:
     {{ bootstrap.load_js() }}
     </body>
 
-You can pass ``version`` to pin the Bootstrap 4 version you want to use. It defaults to load files from CDN. Set ``BOOTSTRAP_SERVE_LOCAL``
+You can pass ``version`` to pin the Bootstrap version you want to use.
+It defaults to load files from CDN. Set ``BOOTSTRAP_SERVE_LOCAL``
 to ``True`` to use built-in local files. However, these methods are optional, you can also write ``<href></href>``
 and ``<script></script>`` tags to include Bootstrap resources (from your ``static`` folder or CDN) manually by yourself.
+If you want to apply a strict Content Security Policy (CSP), you can pass ``nonce`` to ``bootstrap.load_js()``.
+E.g. if using `Talisman
+<https://github.com/wntrblm/flask-talisman>`_ it can be called with ``bootstrap.load_js(nonce=csp_nonce())``.
 
 Starter template
 ----------------

--- a/flask_bootstrap/templates/base/table.html
+++ b/flask_bootstrap/templates/base/table.html
@@ -154,7 +154,7 @@
                   {{ raise('You have to enable the CSRFProtect extension from Flask-WTF to use delete_url, see the docs for more details (https://bootstrap-flask.readthedocs.io/en/stable/macros.html#render-table).') }}
                   {% endif %}
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                <button type="submit" class="btn btn-link p-0 border-0" title="{{ config['BOOTSTRAP_TABLE_DELETE_TITLE'] }}">
+                <button type="submit" class="btn btn-link p-0 border-0 align-baseline" title="{{ config['BOOTSTRAP_TABLE_DELETE_TITLE'] }}">
                     {{ render_icon('trash-fill') }}
                 </button>
             </form>

--- a/flask_bootstrap/templates/base/table.html
+++ b/flask_bootstrap/templates/base/table.html
@@ -143,7 +143,7 @@
                 </a>
             {%- endif %}
             {% if delete_url %}
-            <form style="display:inline"
+            <form class="d-inline"
                   {% if delete_url is string %}
                    action="{{ delete_url }}"
                   {% else %}
@@ -154,11 +154,9 @@
                   {{ raise('You have to enable the CSRFProtect extension from Flask-WTF to use delete_url, see the docs for more details (https://bootstrap-flask.readthedocs.io/en/stable/macros.html#render-table).') }}
                   {% endif %}
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                <a class="action-icon text-decoration-none"
-                    href="javascript:{}"
-                    onclick="this.closest('form').submit();return false;"
-                    title="{{ config['BOOTSTRAP_TABLE_DELETE_TITLE'] }}">
+                <button type="submit" class="btn btn-link p-0 border-0" title="{{ config['BOOTSTRAP_TABLE_DELETE_TITLE'] }}">
                     {{ render_icon('trash-fill') }}
+                  </button>
                 </a>
             </form>
             {% endif %}

--- a/flask_bootstrap/templates/base/table.html
+++ b/flask_bootstrap/templates/base/table.html
@@ -156,8 +156,7 @@
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
                 <button type="submit" class="btn btn-link p-0 border-0" title="{{ config['BOOTSTRAP_TABLE_DELETE_TITLE'] }}">
                     {{ render_icon('trash-fill') }}
-                  </button>
-                </a>
+                </button>
             </form>
             {% endif %}
         </td>

--- a/flask_bootstrap/templates/bootstrap4/form.html
+++ b/flask_bootstrap/templates/bootstrap4/form.html
@@ -6,7 +6,7 @@
         {%- for fieldname, errors in form.errors.items() %}
             {%- if bootstrap_is_hidden_field(form[fieldname]) %}
                 {%- for error in errors %}
-                    <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                    <div class="d-block invalid-feedback">{{ error }}</div>
                 {%- endfor %}
             {%- endif %}
         {%- endfor %}
@@ -75,7 +75,7 @@ the necessary fix for required=False attributes, but will also not set the requi
         {% endif %}
                 {%- if field.errors %}
                     {%- for error in field.errors %}
-                        <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                        <div class="invalid-feedback d-block">{{ error }}</div>
                     {%- endfor %}
                 {%- elif field.description -%}
                     {% call _hz_form_wrap(horizontal_columns, form_type, required=required) %}
@@ -112,11 +112,11 @@ the necessary fix for required=False attributes, but will also not set the requi
         {% endif %}
         {%- if field.errors %}
             {%- for error in field.errors %}
-                <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                <div class="invalid-feedback d-block">{{ error }}</div>
             {%- endfor %}
         {%- elif field.description -%}
             <small class="form-text text-muted">{{ field.description|safe }}</small>
-        {%- endif %} 
+        {%- endif %}
         </div>
     {%- elif field.type == 'SubmitField' -%}
         {# deal with jinja scoping issues? #}

--- a/flask_bootstrap/templates/bootstrap5/form.html
+++ b/flask_bootstrap/templates/bootstrap5/form.html
@@ -6,7 +6,7 @@
         {%- for fieldname, errors in form.errors.items() %}
             {%- if bootstrap_is_hidden_field(form[fieldname]) %}
                 {%- for error in errors %}
-                    <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                <div class="invalid-feedback d-block">{{ error }}</div>
                 {%- endfor %}
             {%- endif %}
         {%- endfor %}
@@ -71,7 +71,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                 {{ field.label(class="form-check-label", for=field.id)|safe }}
                 {%- if field.errors %}
                     {%- for error in field.errors %}
-                        <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                        <div class="invalid-feedback d-block">{{ error }}</div>
                     {%- endfor %}
                 {%- elif field.description -%}
                     {% call _hz_form_wrap(horizontal_columns, form_type, required=required) %}
@@ -108,11 +108,11 @@ the necessary fix for required=False attributes, but will also not set the requi
         {% endif %}
         {%- if field.errors %}
             {%- for error in field.errors %}
-                <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                <div class="invalid-feedback d-block">{{ error }}</div>
             {%- endfor %}
         {%- elif field.description -%}
             <small class="form-text text-muted">{{ field.description|safe }}</small>
-        {%- endif %} 
+        {%- endif %}
         </div>
     {%- elif field.type == 'SubmitField' -%}
         {# deal with jinja scoping issues? #}
@@ -222,7 +222,7 @@ the necessary fix for required=False attributes, but will also not set the requi
                 {%- endif %}
                 {%- if field.errors %}
                     {%- for error in field.errors %}
-                        <div class="invalid-feedback" style="display: block;">{{ error }}</div>
+                        <div class="invalid-feedback d-block">{{ error }}</div>
                     {%- endfor %}
                 {%- elif field.description -%}
                     <small class="form-text text-muted">{{ field.description|safe }}</small>

--- a/flask_bootstrap/templates/bootstrap5/form.html
+++ b/flask_bootstrap/templates/bootstrap5/form.html
@@ -6,7 +6,7 @@
         {%- for fieldname, errors in form.errors.items() %}
             {%- if bootstrap_is_hidden_field(form[fieldname]) %}
                 {%- for error in errors %}
-                <div class="invalid-feedback d-block">{{ error }}</div>
+                    <div class="invalid-feedback d-block">{{ error }}</div>
                 {%- endfor %}
             {%- endif %}
         {%- endfor %}

--- a/tests/test_bootstrap4/test_bootstrap.py
+++ b/tests/test_bootstrap4/test_bootstrap.py
@@ -20,6 +20,7 @@ class TestBootstrap:
                     {% from 'bootstrap/utils.html' import render_icon %}
                     {{ render_icon('heart') }}
                     ''')
+
         with pytest.warns(UserWarning):
             client.get('/test')
 
@@ -70,6 +71,22 @@ class TestBootstrap:
         rv = bootstrap.load_js(version='4.0.0', jquery_version='4.0.0',
                                popper_version='4.0.0')
         _check_assertions(rv)
+
+    def test_load_js_with_nonce(self, bootstrap):
+        nonce = "rAnd0m"
+        rv = bootstrap.load_js(nonce=nonce)
+        bootstrap_js = f'<script src="{CDN_BASE}/bootstrap@{bootstrap.bootstrap_version}/dist/js/bootstrap.min.js"' \
+                       f' integrity="{bootstrap.bootstrap_js_integrity}" crossorigin="anonymous"' \
+                       f' nonce="{nonce}"></script>'
+        jquery_js = f'<script src="{CDN_BASE}/jquery@{bootstrap.jquery_version}/dist/jquery.min.js"' \
+                    f' integrity="{bootstrap.jquery_integrity}" crossorigin="anonymous"' \
+                    f' nonce="{nonce}"></script>'
+        popper_js = f'<script src="{CDN_BASE}/popper.js@{bootstrap.popper_version}/dist/umd/popper.min.js"' \
+                    f' integrity="{bootstrap.popper_integrity}" crossorigin="anonymous"' \
+                    f' nonce="{nonce}"></script>'
+        assert bootstrap_js in rv
+        assert jquery_js in rv
+        assert popper_js in rv
 
     def test_local_resources(self, bootstrap, client):
         current_app.config['BOOTSTRAP_SERVE_LOCAL'] = True

--- a/tests/test_bootstrap5/test_bootstrap5.py
+++ b/tests/test_bootstrap5/test_bootstrap5.py
@@ -52,6 +52,22 @@ class TestBootstrap5:
         rv = bootstrap.load_js(version='5.0.0', popper_version='4.0.0')
         _check_assertions(rv)
 
+    def test_load_js_with_nonce(self, bootstrap):
+        nonce = "rAnd0m"
+        rv = bootstrap.load_js(nonce=nonce)
+        bootstrap_js = f'<script src="{CDN_BASE}/bootstrap@{bootstrap.bootstrap_version}/dist/js/' \
+                       f'bootstrap.min.js" integrity="{bootstrap.bootstrap_js_integrity}" ' \
+                       f'crossorigin="anonymous" nonce="{nonce}"></script>'
+        jquery_js = f'<script src="{CDN_BASE}/jquery@{bootstrap.jquery_version}/dist/jquery.min.js"' \
+                    f' integrity="{bootstrap.jquery_integrity}" crossorigin="anonymous"' \
+                    f' nonce="{nonce}"></script>'
+        popper_js = f'<script src="{CDN_BASE}/@popperjs/core@{bootstrap.popper_version}/dist/umd/popper.min.js"' \
+                    f' integrity="{bootstrap.popper_integrity}" crossorigin="anonymous"' \
+                    f' nonce="{nonce}"></script>'
+        assert bootstrap_js in rv
+        assert jquery_js not in rv
+        assert popper_js in rv
+
     def test_local_resources(self, bootstrap, client):
         current_app.config['BOOTSTRAP_SERVE_LOCAL'] = True
 


### PR DESCRIPTION
To support the usage of Boostrap-Flask together with a [strict Content Security Policy (CSP)](https://csp.withgoogle.com/docs/strict-csp.html), to have a defense in depth against XSS attacks, the following changes have been made:

1. Remove inline style declarations, use classes instead
2. Remove inline JS, use HTML + CSS instead
3. Add support of nonces with JS includes
4. Add basic usage documentation

If desired I can still add an example and/or test case for this use case.