### PR TITLE
New feature: reversible sort links

### DIFF
--- a/flask_bootstrap/templates/base/utils.html
+++ b/flask_bootstrap/templates/base/utils.html
@@ -30,3 +30,48 @@
         {{ url_for(endpoint, **kargs) }}
     {%- endwith %}
 {%- endmacro %}
+
+
+{% macro render_sortlink(
+    attr,
+    text = attr | title,
+    icon_asc = config.BOOTSTRAP_SORT_ICON_ASC or "caret-up",
+    icon_desc = config.BOOTSTRAP_SORT_ICON_DESC or "caret-down",
+    sort_style = config.BOOTSTRAP_SORT_STYLE or "csv",
+    sort_param = config.BOOTSTRAP_SORT_PARAM or "sort",
+    sort_dir_param = config.BOOTSTRAP_SORT_DIR_PARAM or "dir",
+    sort_asc_value = config.BOOTSTRAP_SORT_ASC_VALUE or "asc",
+    sort_desc_value = config.BOOTSTRAP_SORT_DESC_VALUE or "desc",
+    sort_title_template = config.SORT_TITLE_TEMPLATE or "Sort %s (%s)",
+    sort_value_name_map = config.SORT_VALUE_NAME_MAP or {"asc": "Ascending", "desc": "Descending"}
+
+    ) %}
+
+    {% if sort_style == "csv" %}
+    {% set curr_attr, _, curr_dir = request.args.get(sort_param, "").partition(",")%}
+    {% else %}
+    {% set curr_attr = request.args.get(sort_param) %}
+    {% set curr_dir = request.args.get(sort_dir_param) %}
+    {% endif %}
+
+    {% set desired_dir = sort_desc_value if curr_attr == attr and curr_dir == sort_asc_value else
+    sort_asc_value %}
+
+    {% set args = request.args.copy() %}
+
+    {% if sort_style == "csv" %}
+    {% set _ = args.setlist(sort_param, ["%s,%s" | format(attr, desired_dir)])%}
+    {% else %}
+    {% set _ = args.setlist(sort_param, [attr])%}
+    {% set _ = args.setlist(sort_dir_param, [desired_dir]) %}
+    {% endif %}
+
+    {% if sort_title_template %}
+    {% set _ = link_attrs.update({"title":sort_title_template | format(text, sort_value_name_map[desired_dir])}) %}
+    {% endif %}
+
+    <span class="text-nowrap">
+        <a href="{{url_for(request.endpoint, **args)}}">{{text}}</a>
+        {{render_icon(icon_asc if desired_dir == sort_desc_value else icon_desc) if attr == curr_attr}}
+    </span>
+    {% endmacro %}

--- a/flask_bootstrap/templates/base/utils.html
+++ b/flask_bootstrap/templates/base/utils.html
@@ -71,7 +71,7 @@
     {% endif %}
 
     <span class="text-nowrap">
-        <a href="{{url_for(request.endpoint, **args)}}">{{text}}</a>
+        <a href="{{url_for(request.endpoint, **args)}}" {{link_attrs|xmlattr}}>{{text}}</a>
         {{render_icon(icon_asc if desired_dir == sort_desc_value else icon_desc) if attr == curr_attr}}
     </span>
     {% endmacro %}

--- a/flask_bootstrap/templates/base/utils.html
+++ b/flask_bootstrap/templates/base/utils.html
@@ -43,8 +43,8 @@
     sort_asc_value = config.BOOTSTRAP_SORT_ASC_VALUE or "asc",
     sort_desc_value = config.BOOTSTRAP_SORT_DESC_VALUE or "desc",
     sort_title_template = config.SORT_TITLE_TEMPLATE or "Sort %s (%s)",
-    sort_value_name_map = config.SORT_VALUE_NAME_MAP or {"asc": "Ascending", "desc": "Descending"}
-
+    sort_value_name_map = config.SORT_VALUE_NAME_MAP or {"asc": "Ascending", "desc": "Descending"},
+    link_attrs = {}
     ) %}
 
     {% if sort_style == "csv" %}

--- a/tests/test_bootstrap4/test_render_sortlink.py
+++ b/tests/test_bootstrap4/test_render_sortlink.py
@@ -1,0 +1,24 @@
+from flask import render_template_string
+
+
+def test_render_sortlink(app, client):
+    @app.route("/sortlink")
+    def sortlink():
+        return render_template_string(
+            """
+        {% from 'bootstrap4/utils.html' import render_sortlink %}
+            {{ render_sortlink('foo') }}
+        """
+        )
+
+    response = client.get("/sortlink")
+    data = response.get_data(as_text=True)
+    assert "?sort=foo,asc" in data
+
+    response = client.get("/sortlink?sort=foo,asc")
+    data = response.get_data(as_text=True)
+    assert "?sort=foo,desc" in data
+
+    response = client.get("/sortlink?sort=foo,desc")
+    data = response.get_data(as_text=True)
+    assert "?sort=foo,asc" in data


### PR DESCRIPTION
Added a new macro: render_sortlink. This renders hyperlinks to sort by a given field in a given direction, and its reverse

`{{ render_sortlink('foo') }} `

will render HTML:

```
<span class="text-nowrap">
        <a href="/?sort=foo,asc">Foo</a>
</span>
```

when clicked again, will render:

```
<span class="text-nowrap">
    <a href="/?sort=foo,desc">Foo</a>
    <svg class="bi" width="1em" height="1em" fill="currentColor">
        <use xlink:href="/bootstrap/static/icons/bootstrap-icons.svg#caret-up"></use>
    </svg>
</span>
```

when clicked again will render:

```
<span class="text-nowrap">
    <a href="/?sort=foo,asc">Foo</a>
    <svg class="bi" width="1em" height="1em" fill="currentColor">
        <use xlink:href="/bootstrap/static/icons/bootstrap-icons.svg#caret-down"></use>
    </svg>
</span>
```

maintains state with respect to other query string parameters

configurable to use different icons, or sort "styles", like `?sort=foo,asc` vs `?field=foo&asc=1`

