### PR TITLE
Update import of markupsafe.Markup

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -1,6 +1,7 @@
 import warnings
 
-from flask import current_app, Markup, Blueprint, url_for
+from flask import current_app, Blueprint, url_for
+from markupsafe import Markup
 from wtforms import BooleanField, HiddenField
 
 CDN_BASE = 'https://cdn.jsdelivr.net/npm'


### PR DESCRIPTION
This addresses a deprecation warning for the upcoming minor release of Flask:

```
DeprecationWarning: 'flask.Markup' is deprecated and will be removed in Flask 2.4. Import 'markupsafe.Markup' instead.
    from flask import current_app, Markup, Blueprint, url_for
```