### PR TITLE
Minor typos in Macros.rst

### DIFF
--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -576,7 +576,7 @@ Here is the full example:
 
     {{ render_table(data, view_url=('view_message', [('message_id', ':id')])) }}
 
-The following arguments are expect to accpet an URL tuple:
+The following arguments are expected to accept a URL tuple:
 
 - ``custom_actions``
 - ``view_url``


### PR DESCRIPTION
Just noticed these while browsing the docs.