### PR TITLE
WIP extend nav and breadcrumb badge support and whitespace reduction

### DIFF
--- a/examples/bootstrap5/templates/base.html
+++ b/examples/bootstrap5/templates/base.html
@@ -31,8 +31,8 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
                 {{ render_nav_item('index', 'Home') }}
-                {{ render_nav_item('test_form', 'Form') }}
-                {{ render_nav_item('test_nav', 'Nav') }}
+                {{ render_nav_item('test_form', 'Form', _use_li=True) }}
+                {{ render_nav_item('test_nav', 'Nav', _badge='New', _badge_style='Light') }}
                 {{ render_nav_item('test_bootswatch', 'Bootswatch') }}
                 {{ render_nav_item('test_pagination', 'Pagination') }}
                 {{ render_nav_item('test_flash', 'Flash Messages') }}

--- a/examples/bootstrap5/templates/nav.html
+++ b/examples/bootstrap5/templates/nav.html
@@ -4,8 +4,8 @@
 {% block content %}
 <h2>Render Navbar item with render_nav_item</h2>
 <pre>{% raw %}
-{{ render_nav_item('test_form', 'Form') }}
-{{ render_nav_item('test_nav', 'Nav') }}
+{{ render_nav_item('test_form', 'Form', _use_li=True) }}
+{{ render_nav_item('test_nav', 'Nav', _badge='New', _badge_style='Light') }}
 {{ render_nav_item('test_pagination', 'Pagination') }}
 {{ render_nav_item('test_static', 'Static') }}
 {{ render_nav_item('test_flash', 'Flash Messages') }}
@@ -17,8 +17,8 @@
     </button>
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <div class="navbar-nav mr-auto">
-            {{ render_nav_item('test_form', 'Form') }}
-            {{ render_nav_item('test_nav', 'Nav') }}
+            {{ render_nav_item('test_form', 'Form', _use_li=True) }}
+            {{ render_nav_item('test_nav', 'Nav', _badge='New', _badge_style='Light') }}
             {{ render_nav_item('test_pagination', 'Pagination') }}
             {{ render_nav_item('test_flash', 'Flash Messages') }}
         </div>
@@ -28,14 +28,14 @@
 <h2>Render Breadcrumb item with render_breadcrumb_item</h2>
 <pre>{% raw %}
 {{ render_breadcrumb_item('test_form', 'Form') }}
-{{ render_breadcrumb_item('test_nav', 'Nav') }}
+{{ render_breadcrumb_item('test_nav', 'Nav', _badge='17', _badge_pill=True) }}
 {{ render_breadcrumb_item('test_pagination', 'Pagination') }}
 {{ render_breadcrumb_item('test_flash', 'Flash Messages') }}
 {% endraw %}</pre>
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         {{ render_breadcrumb_item('test_form', 'Form') }}
-        {{ render_breadcrumb_item('test_nav', 'Nav') }}
+        {{ render_breadcrumb_item('test_nav', 'Nav', _badge='17', _badge_pill=True) }}
         {{ render_breadcrumb_item('test_pagination', 'Pagination') }}
         {{ render_breadcrumb_item('test_flash', 'Flash Messages') }}
     </ol>

--- a/flask_bootstrap/templates/base/nav.html
+++ b/flask_bootstrap/templates/base/nav.html
@@ -1,21 +1,27 @@
-{% macro render_nav_item(endpoint, text, _badge='', _use_li=False) %}
-    {% set active = True if request.endpoint and request.endpoint == endpoint else False %}
-    {% if _use_li %}<li class="nav-item">{% endif %}
-    <a class="{% if not _use_li %}nav-item {% endif %}nav-link{% if active %} active" aria-current="page{% endif %}"
-       href="{{ url_for(endpoint, **kwargs) }}">
-        {{ text }} {% if _badge %}<span class="badge badge-light">{{ _badge }}</span>{% endif %}
+{% macro render_nav_item(endpoint, text, _badge=None, _badge_pill=False, _badge_style=config.BOOTSTRAP_BTN_STYLE, _use_li=False) %}
+    {%- set active = True if request.endpoint and request.endpoint == endpoint else False -%}
+    {% if _use_li -%}
+    <li class="nav-item">
+    {%- endif -%}
+    <a class="{% if not _use_li %}nav-item {% endif %}nav-link{% if active %} active" aria-current="page{% endif %}" href="{{ url_for(endpoint, **kwargs) }}">{{ text }}
+    {%- if _badge %} <span class="badge{%if _badge_pill %} badge-pill{% endif %} badge-{% if _badge_style %}{{ _badge_style }}{% else %}light{% endif %}">{{ _badge }}</span>{% endif -%}
     </a>
-    {% if _use_li %}</li>{% endif %}
+    {%- if _use_li -%}
+    </li>
+    {%- endif -%}
 {% endmacro %}
 
 
-{% macro render_breadcrumb_item(endpoint, text) %}
-    {% set active = True if request.endpoint and request.endpoint == endpoint else False %}
+{% macro render_breadcrumb_item(endpoint, text, _badge=None, _badge_pill=False, _badge_style=config.BOOTSTRAP_BTN_STYLE) %}
+    {%- set active = True if request.endpoint and request.endpoint == endpoint else False -%}
     <li class="breadcrumb-item{% if active %} active" aria-current="page{% endif %}">
-        {% if active %}
-            {{ text }}
-        {% else %}
-        <a href="{{ url_for(endpoint, **kwargs) }}">{{ text }}</a>
-        {% endif %}
+        {%- if not active -%}
+        <a href="{{ url_for(endpoint, **kwargs) }}">
+        {%- endif -%}
+        {{ text }}
+        {%- if _badge %} <span class="badge{%if _badge_pill %} badge-pill{% endif %} badge-{% if _badge_style %}{{ _badge_style }}{% else %}light{% endif %}">{{ _badge }}</span>{% endif -%}
+        {%- if not active -%}
+        </a>
+        {%- endif -%}
     </li>
 {% endmacro %}


### PR DESCRIPTION
The result of this PR is a huge reduction of whitespace in navigation items and breadcrumb items.

This supports the development of https://github.com/helloflask/bootstrap-flask/issues/336 and https://github.com/helloflask/bootstrap-flask/issues/191

I would like to suggest dropping the underscore of the `_badge` parameter in `render_nav_item`, but that will break backward compatibility. However, the other badge parameters will also not need one.

Additional question, the badge is currently shown as white text on white background. How to fix this?

After these questions have been answered, documentation and tests will be added.