### PR TITLE
Adding body_classes parameter to render_table

### DIFF
--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -491,6 +491,7 @@ API
                               caption=None,\
                               table_classes=None,\
                               header_classes=None,\
+                              body_classes=None,\
                               responsive=False,\
                               responsive_class='table-responsive',\
                               safe_columns=None,\
@@ -512,6 +513,7 @@ API
     :param caption: A caption to attach to the table.
     :param table_classes: A string of classes to apply to the table (e.g ``'table-small table-dark'``).
     :param header_classes: A string of classes to apply to the table header (e.g ``'thead-dark'``).
+    :param body_classes: A string of classes to apply to the table body (e.g ``'table-group-divider'``).
     :param responsive: Whether to enable/disable table responsiveness.
     :param responsive_class: The responsive class to apply to the table. Default is ``'table-responsive'``.
     :param safe_columns: Tuple with columns names to render HTML safe using ``|safe``.

--- a/examples/bootstrap5/templates/table.html
+++ b/examples/bootstrap5/templates/table.html
@@ -7,8 +7,8 @@
 {{ render_table(messages) }}
 
 <h2>Customized Table</h2>
-<pre>{% raw %}{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}{% endraw %}</pre>
-{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', caption='Messages') }}
+<pre>{% raw %}{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', body_classes='table-group-divider', caption='Messages') }}{% endraw %}</pre>
+{{ render_table(messages, titles, table_classes='table-striped', header_classes='thead-dark', body_classes='table-group-divider', caption='Messages') }}
 
 <h2>Responsive Table</h2>
 <pre>{% raw %}{{ render_table(messages, responsive=True, responsive_class='table-responsive-sm') }}{% endraw %}</pre>

--- a/flask_bootstrap/templates/base/table.html
+++ b/flask_bootstrap/templates/base/table.html
@@ -30,6 +30,7 @@
                       caption=None,
                       table_classes=None,
                       header_classes=None,
+                      body_classes=None,
                       responsive=False,
                       responsive_class='table-responsive',
                       safe_columns=None,
@@ -75,7 +76,7 @@
     {% endif %}
     </tr>
     </thead>
-    <tbody>
+    <tbody{% if body_classes %} class="{{ body_classes }}"{% endif %}>
     {% for row in data %}
     <tr>
         {% for title in titles %}

--- a/tests/test_bootstrap4/test_render_table.py
+++ b/tests/test_bootstrap4/test_render_table.py
@@ -125,13 +125,15 @@ def test_render_customized_table(app, client):
         return render_template_string('''
                                 {% from 'bootstrap4/table.html' import render_table %}
                                 {{ render_table(messages, titles, table_classes='table-striped',
-                                header_classes='thead-dark', caption='Messages') }}
+                                header_classes='thead-dark', body_classes='table-group-divider',
+                                caption='Messages') }}
                                 ''', titles=titles, messages=messages)
 
     response = client.get('/table')
     data = response.get_data(as_text=True)
     assert '<table class="table table-striped">' in data
     assert '<thead class="thead-dark">' in data
+    assert '<tbody class="table-group-divider">' in data
     assert '<caption>Messages</caption>' in data
 
 


### PR DESCRIPTION
Table group dividers is available in [Bootstrap v5.2+](https://getbootstrap.com/docs/5.2/content/tables/#table-group-dividers)

Adding `body_classes` parameter to `render_table()` to be able to use that style.

* updated test 
* updated documentation
* updated bootstrap5 example app

<img width="1342" alt="Screenshot 2024-01-05 at 2 30 21 PM" src="https://github.com/helloflask/bootstrap-flask/assets/1578811/3b2e9d41-7b27-411a-97ba-74a3a3649d1d">
