### PR TITLE
Fix icon font loading issue when BOOTSTRAP_SERVE_LOCAL is True

### DIFF
--- a/flask_bootstrap/__init__.py
+++ b/flask_bootstrap/__init__.py
@@ -131,7 +131,7 @@ class _Bootstrap:
         """
         serve_local = current_app.config['BOOTSTRAP_SERVE_LOCAL']
         if serve_local:
-            icons_url = url_for('bootstrap.static', filename='font/bootstrap-icons.min.css')
+            icons_url = url_for('bootstrap.static', filename='css/font/bootstrap-icons.min.css')
         else:
             icons_url = f'{CDN_BASE}/bootstrap-icons@{self.icons_version}/font/bootstrap-icons.min.css'
         css = f'<link rel="stylesheet" href="{icons_url}">'


### PR DESCRIPTION
Fixed an issue where the icon font CSS was not properly loaded in templates using `{{ bootstrap.load_icon_font_css() }}` when `BOOTSTRAP_SERVE_LOCAL` was set to True. 

The error was due to an incorrect path specification. The path has been corrected in `flask_bootstrap/__init__.py` from `font/bootstrap-icons.min.css` to `css/font/bootstrap-icons.min.css` on line 134, ensuring that the icon font CSS loads correctly.